### PR TITLE
Switch to XS-Go-Import-Path

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Standards-Version: 3.9.7
 Homepage: http://github.com/mvo5/goconfigparser
 Vcs-Browser: https://github.com/vorlonofportland/goconfigparser/tree/debian
 Vcs-Git: https://github.com/vorlonofportland/goconfigparser -b debian
+XS-Go-Import-Path: github.com/mvo5/goconfigparser
 
 Package: golang-github-mvo5-goconfigparser-dev
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,6 @@
 #export DH_VERBOSE=1
 export DH_OPTIONS
 
-export DH_GOPKG := github.com/mvo5/goconfigparser
 
 %:
 	dh $@ --buildsystem=golang --with=golang --builddirectory=$(BUILDDIR)


### PR DESCRIPTION
Using the XS-Go-Import-Path field in debian/control is preferable over using
DH_GOPKG in debian/rules, because the former shows up in a machine-readable way
in Sources files, and can hence be easily picked up by tooling.
