### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+golang-github-mvo5-goconfigparser (0.2.1-2) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + golang-github-mvo5-goconfigparser-dev: Add Multi-Arch: foreign.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Sep 2020 23:53:29 -0000
+
 golang-github-mvo5-goconfigparser (0.2.1-1) unstable; urgency=medium
 
   * Initial Debian upload.

--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Replaces: golang-goconfigparser-dev (<< 0.2-0ubuntu3~)
 Breaks: golang-goconfigparser-dev (<< 0.2-0ubuntu3~)
+Multi-Arch: foreign
 Description: Python compatible INI parser
  This parser is build as a go equivalent of the Python ConfigParser
  module and is aimed for maximum compatibility for both the file format


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* golang-github-mvo5-goconfigparser-dev: Add Multi-Arch: foreign. This fixes: golang-github-mvo5-goconfigparser-dev could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/golang-github-mvo5-goconfigparser/bba55906-e450-4f26-b4de-a88f0fac3c2b.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/bba55906-e450-4f26-b4de-a88f0fac3c2b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/bba55906-e450-4f26-b4de-a88f0fac3c2b/diffoscope)).
